### PR TITLE
Improve comparision of arrays with repeated or empty elements

### DIFF
--- a/lib/index.iced
+++ b/lib/index.iced
@@ -30,7 +30,7 @@ objectDiff = (obj1, obj2) ->
     score += Math.min(20, Math.max(-10, subscore / 5))  # BATMAN!
 
   if Object.keys(result).length is 0
-    [score, result] = [100 * Object.keys(obj1).length, undefined]
+    [score, result] = [100 * Math.max(Object.keys(obj1).length, 0.5), undefined]
   else
     score = Math.max(0, score)
 

--- a/test/diff_test.coffee
+++ b/test/diff_test.coffee
@@ -19,6 +19,9 @@ describe 'diff', ->
 
   describe 'with objects', ->
 
+    it "should return undefined for two empty objects", ->
+      assert.deepEqual undefined, diff({ }, { })
+
     it "should return undefined for two objects with identical contents", ->
       assert.deepEqual undefined, diff({ foo: 42, bar: 10 }, { foo: 42, bar: 10 })
 
@@ -55,6 +58,12 @@ describe 'diff', ->
 
     it "should return undefined for two arrays with identical contents", ->
       assert.deepEqual undefined, diff([{ foo: 10 }, { foo: 20 }, { foo: 30 }], [{ foo: 10 }, { foo: 20 }, { foo: 30 }])
+
+    it "should return undefined for two arrays with identical, empty object contents", ->
+      assert.deepEqual undefined, diff([{ }], [{ }])
+
+    it "should return undefined for two arrays with identical, empty array contents", ->
+      assert.deepEqual undefined, diff([[]], [[]])
 
     it "should return undefined for two arrays with identical, repeated contents", ->
       assert.deepEqual undefined, diff([{ a: 1, b: 2 }, { a: 1, b: 2 }], [{ a: 1, b: 2 }, { a: 1, b: 2 }])


### PR DESCRIPTION
`diff([ a, a, a ], [ a, a, a ])` incorrectly reports that all but the first element were changed when `a` is a non-empty object, and that all elements were changed if `a` is `{}`.

fixes andreyvit/json-diff#1
