### PR TITLE
Exit with non-zero status if files do not match

### DIFF
--- a/lib/cli.iced
+++ b/lib/cli.iced
@@ -44,3 +44,5 @@ module.exports = (argv) ->
   else
     process.stderr.write "Producing colored output...\n"  if options.verbose
     process.stdout.write colorize(result, color: options.color)
+
+  process.exit 1 if result


### PR DESCRIPTION
Make `json-diff` behave like `diff`
