### PR TITLE
Fix colliding fuzzy matches

### DIFF
--- a/lib/index.iced
+++ b/lib/index.iced
@@ -39,12 +39,12 @@ objectDiff = (obj1, obj2) ->
   return [score, result]
 
 
-findMatchingObject = (item, index, fuzzyOriginals) ->
+findMatchingObject = (item, index, fuzzyOriginals, used) ->
   # console.log "findMatchingObject: " + JSON.stringify({item, fuzzyOriginals}, null, 2)
   bestMatch = null
 
   matchIndex = 0
-  for own key, candidate of fuzzyOriginals when key isnt '__next'
+  for own key, candidate of fuzzyOriginals when key isnt '__next' and !used[key]?
     indexDistance = Math.abs(matchIndex - index)
     if extendedTypeOf(item) == extendedTypeOf(candidate)
       score = diffScore(item, candidate)
@@ -60,7 +60,7 @@ scalarize = (array, originals, fuzzyOriginals) ->
   for item, index in array
     if isScalar item
       item
-    else if fuzzyOriginals && (bestMatch = findMatchingObject(item, index, fuzzyOriginals)) && bestMatch.score > 40
+    else if fuzzyOriginals && (bestMatch = findMatchingObject(item, index, fuzzyOriginals, originals)) && bestMatch.score > 40
       originals[bestMatch.key] = item
       bestMatch.key
     else

--- a/lib/index.iced
+++ b/lib/index.iced
@@ -39,12 +39,12 @@ objectDiff = (obj1, obj2) ->
   return [score, result]
 
 
-findMatchingObject = (item, index, fuzzyOriginals, used) ->
+findMatchingObject = (item, index, fuzzyOriginals) ->
   # console.log "findMatchingObject: " + JSON.stringify({item, fuzzyOriginals}, null, 2)
   bestMatch = null
 
   matchIndex = 0
-  for own key, candidate of fuzzyOriginals when key isnt '__next' and !used[key]?
+  for own key, candidate of fuzzyOriginals when key isnt '__next'
     indexDistance = Math.abs(matchIndex - index)
     if extendedTypeOf(item) == extendedTypeOf(candidate)
       score = diffScore(item, candidate)
@@ -60,7 +60,7 @@ scalarize = (array, originals, fuzzyOriginals) ->
   for item, index in array
     if isScalar item
       item
-    else if fuzzyOriginals && (bestMatch = findMatchingObject(item, index, fuzzyOriginals, originals)) && bestMatch.score > 40
+    else if fuzzyOriginals && (bestMatch = findMatchingObject(item, index, fuzzyOriginals)) && bestMatch.score > 40 && !originals[bestMatch.key]?
       originals[bestMatch.key] = item
       bestMatch.key
     else


### PR DESCRIPTION
Diffing the following two arrays shows "c" incorrectly being added to the first object.

a.json:

[
  { "name": "Foo", "a": 3, "b": 1 }
]

b.json

[
  { "name": "Foo", "a": 3, "b": 1 },
  { "name": "Foo", "a": 3, "b": 1, "c": 1 }
]

In `scalarize`, it maps a target array's objects to matching source objects, but it doesn't check whether the mapping exists already.

```
    else if fuzzyOriginals && (bestMatch = findMatchingObject(item, index, fuzzyOriginals)) && bestMatch.score > 40
      originals[bestMatch.key] = item;
```

The proposed change passes all existing mappings into findMatchingObject and does the check there so that an alternate match can be found.
