### PR TITLE
Colliding fuzzy matches test case

### DIFF
--- a/lib/index.iced
+++ b/lib/index.iced
@@ -60,7 +60,7 @@ scalarize = (array, originals, fuzzyOriginals) ->
   for item, index in array
     if isScalar item
       item
-    else if fuzzyOriginals && (bestMatch = findMatchingObject(item, index, fuzzyOriginals)) && bestMatch.score > 40
+    else if fuzzyOriginals && (bestMatch = findMatchingObject(item, index, fuzzyOriginals)) && bestMatch.score > 40 && !originals[bestMatch.key]?
       originals[bestMatch.key] = item
       bestMatch.key
     else

--- a/test/diff_test.coffee
+++ b/test/diff_test.coffee
@@ -74,6 +74,9 @@ describe 'diff', ->
     it "should return [..., ['+', <added item>], ...] for two arrays when the second array has an extra value", ->
       assert.deepEqual [[' '], ['+', { foo: 20 }], [' ']], diff([{ foo: 10 }, { foo: 30 }], [{ foo: 10 }, { foo: 20 }, { foo: 30 }])
 
+    it "should return [..., ['+', <added item>], ...] for two arrays when the second array has a new but nearly identical object added", ->
+      assert.deepEqual [[' '],[ '+', { name: 'Foo', a: 3, b: 1, c: 1 }], [' ']], diff([{ "name": "Foo", "a": 3, "b": 1 },{ foo: 10 }], [{ "name": "Foo", "a": 3, "b": 1 },{ "name": "Foo", "a": 3, "b": 1, "c": 1 },{ foo: 10 }])
+
     it "should return [..., ['~', <diff>], ...] for two arrays when an item has been modified (note: involves a crazy heuristic)", ->
       assert.deepEqual [[' '], ['~', { foo: { __old: 20, __new: 21 } }], [' ']], diff([{ foo: 10, bar: { bbbar: 10, bbboz: 11 } }, { foo: 20, bar: { bbbar: 50, bbboz: 25 } }, { foo: 30, bar: { bbbar: 92, bbboz: 34 } }], [{ foo: 10, bar: { bbbar: 10, bbboz: 11 } }, { foo: 21, bar: { bbbar: 50, bbboz: 25 } }, { foo: 30, bar: { bbbar: 92, bbboz: 34 } }])
 


### PR DESCRIPTION
basically it's squashed #8 with a test added

I cherry-picked the new test into master to verify it fails before and succeeds after this patch... and all the other tests still work, I didn't really bother trying to understand the change too much, I just added a test case and it does seem to generate a better diff...

Here is the error this test surfaces

```
AssertionError: [[" "],["+",{"name":"Foo","a":3,"b":1,"c":1}],[" "]] deepEqual [["+",{"name":"Foo","a":3,"b":1,"c":1}],["~",{"c__added":1}],[" "]]
```
