### PR TITLE
Output nothing if no diff is found

### DIFF
--- a/lib/colorize.iced
+++ b/lib/colorize.iced
@@ -52,7 +52,9 @@ subcolorizeToCallback = (key, diff, output, color, indent) ->
       output color, "#{indent}]"
 
     else
-      output(color, indent + prefix + JSON.stringify(diff))
+      if diff == 0 or diff
+        output(color, indent + prefix + JSON.stringify(diff))
+
 
 
 colorizeToCallback = (diff, output) ->

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "bin": "bin/json-diff.js",
   "scripts": {
     "test": "./node_modules/mocha/bin/mocha test/*.coffee",
-    "cov":  "rm -rf lib-cov; jscoverage lib lib-cov; env JSLIB=lib-cov mocha -R dot && env JSLIB=lib-cov mocha -R html-cov >coverage.html; open coverage.html"
+    "cov": "rm -rf lib-cov; jscoverage lib lib-cov; env JSLIB=lib-cov mocha -R dot && env JSLIB=lib-cov mocha -R html-cov >coverage.html; open coverage.html"
   },
   "dependencies": {
     "dreamopt": "~0.6.0",
@@ -19,9 +19,9 @@
     "cli-color": "~0.1.6"
   },
   "devDependencies": {
-    "mocha": "~1.7.0",
     "coffee-script": "~1.7.1",
-    "iced-coffee-script": "~1.7.1"
+    "iced-coffee-script": "^1.8.0-d",
+    "mocha": "~1.7.0"
   },
   "optionalDependencies": {},
   "engines": {

--- a/test/diff_test.coffee
+++ b/test/diff_test.coffee
@@ -89,3 +89,6 @@ describe 'diffString', ->
 
   it "should produce the expected colored result for the example JSON files", ->
     assert.equal diffString(a, b), readExampleFile('result-colored.jsdiff')
+
+  it "return an empty string when no diff found", ->
+    assert.equal diffString(a, a), ''


### PR DESCRIPTION
When there is no difference between files, json-diff outputs a string that looks like `"  undefined"`. This can be confusing: if used as a dependency in another project, you might spend some time scratching your head over why neither `undefined === undefined` nor `"undefined" === "undefined"` appear to be true. 

Also, outputting nothing seems like a better default when no diff is found. 