### PR TITLE
patch for No-diff in colored and raw json output

### DIFF
--- a/lib/cli.iced
+++ b/lib/cli.iced
@@ -38,11 +38,14 @@ module.exports = (argv) ->
 
   options.color ?= tty.isatty(process.stdout.fd)
 
-  if options.raw
-    process.stderr.write "Serializing JSON output...\n"  if options.verbose
-    process.stdout.write JSON.stringify(result, null, 2)
+  if result
+    if options.raw
+      process.stderr.write "Serializing JSON output...\n"  if options.verbose
+      process.stdout.write JSON.stringify(result, null, 2)
+    else
+      process.stderr.write "Producing colored output...\n"  if options.verbose
+      process.stdout.write colorize(result, color: options.color)
   else
-    process.stderr.write "Producing colored output...\n"  if options.verbose
-    process.stdout.write colorize(result, color: options.color)
+    process.stderr.write "No diff" if options.verbose
 
   process.exit 1 if result


### PR DESCRIPTION
json-diff 0.3.1 has problem for same inputs.

```
$ cat a.json
[]
$ cat b.json
[]
$ node_modules/.bin/json-diff a.json b.json
 undefined
$ node_modules/.bin/json-diff -j a.json b.json

net.js:612
    throw new TypeError('invalid data');
          ^
TypeError: invalid data
    at WriteStream.Socket.write (net.js:612:11)
    at _Class.continuation (/home/chinachu/chinachu-scripts/node_modules/json-diff/lib/cli.js:101:31)
    at _Class.iced.Deferrals._Class._fulfill (/home/chinachu/chinachu-scripts/node_modules/json-diff/lib/cli.js:16:40)
    at /home/chinachu/chinachu-scripts/node_modules/json-diff/lib/cli.js:30:24
    at fs.js:268:14
    at Object.oncomplete (fs.js:107:15)
```

I wrote simple patch. But I can't test my patch.
How to test my npm-module?
