### PR TITLE
Fix behaviour for "null" values

### DIFF
--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -2,7 +2,7 @@
 { extendedTypeOf } = require './util'
 { colorize } = require './colorize'
 
-isScalar = (obj) -> (typeof obj isnt 'object')
+isScalar = (obj) -> (typeof obj isnt 'object' || obj == null)
 
 
 objectDiff = (obj1, obj2, options = {}) ->

--- a/test/diff_test.coffee
+++ b/test/diff_test.coffee
@@ -65,6 +65,9 @@ describe 'diff', ->
     it "should return undefined for two arrays with identical, empty array contents", ->
       assert.deepEqual undefined, diff([[]], [[]])
 
+    it "should return undefined for two arrays with identical, array contents including 'null'", ->
+      assert.deepEqual undefined, diff([1, null, null], [1, null, null])
+
     it "should return undefined for two arrays with identical, repeated contents", ->
       assert.deepEqual undefined, diff([{ a: 1, b: 2 }, { a: 1, b: 2 }], [{ a: 1, b: 2 }, { a: 1, b: 2 }])
 


### PR DESCRIPTION
Previously the diffing behaviour broke for "null" values since they got handled as "non-scalar".