### PR TITLE
Collapse elisions (resolves #41)

### DIFF
--- a/example/big_a.json
+++ b/example/big_a.json
@@ -1,0 +1,54 @@
+{
+  "movies": [
+    {
+      "title": "Star Wars: Episode IV - A New Hope",
+      "directors": ["George Lucas"],
+      "year": 1977
+    },
+    {
+      "title": "Starship Troopers",
+      "directors": ["Paul Verhoeven"],
+      "year": 1997
+    },
+    {
+      "title": "Fight Club",
+      "directors": ["David Fincher"],
+      "year": 1999
+    },
+    {
+      "title": "Groundhog Day",
+      "directors": ["Harold Ramis"],
+      "year": 1993
+    },
+    {
+      "title": "Serenity",
+      "directors": ["Joss Wheldon"],
+      "year": 2005
+    },
+    {
+      "title": "Tron",
+      "directors": ["Steven Lisberger"],
+      "year": 1982
+    },
+    {
+      "title": "The Matrix",
+      "directors": ["Lana Wachowski", "Lilly Wachowski"],
+      "year": 1999
+    },
+    {
+      "title": "Blade Runner",
+      "directors": ["Ridley Scott"],
+      "year": 1982
+    },
+    {
+      "title": "Monty Python and the Holy Grail",
+      "directors": ["Terry Gilliam"],
+      "year": 1975
+    },
+    {
+      "title": "2001: A Space Odyssey",
+      "directors": ["Stanley Kubrick"],
+      "year": 1968
+    }
+  ]
+}

--- a/example/big_b.json
+++ b/example/big_b.json
@@ -1,0 +1,54 @@
+{
+  "movies": [
+    {
+      "title": "Star Wars: Episode IV - A New Hope",
+      "directors": ["George Lucas"],
+      "year": 1977
+    },
+    {
+      "title": "Starship Troopers",
+      "directors": ["Paul Verhoeven"],
+      "year": 1997
+    },
+    {
+      "title": "Fight Club",
+      "directors": ["David Fincher"],
+      "year": 1999
+    },
+    {
+      "title": "Groundhog Day",
+      "directors": ["Harold Ramis"],
+      "year": 1993
+    },
+    {
+      "title": "Serenity",
+      "directors": ["Joss Wheldon"],
+      "year": 2005
+    },
+    {
+      "title": "Tron",
+      "directors": ["Steven Lisberger"],
+      "year": 1982
+    },
+    {
+      "title": "The Matrix",
+      "directors": ["Lana Wachowski", "Lilly Wachowski"],
+      "year": 1999
+    },
+    {
+      "title": "Blade Runner",
+      "directors": ["Ridley Scott"],
+      "year": 1982
+    },
+    {
+      "title": "Monty Python and the Holy Grail",
+      "directors": ["Terry Gilliam", "Terry Jones"],
+      "year": 1975
+    },
+    {
+      "title": "2001: A Space Odyssey",
+      "directors": ["Stanley Kubrick"],
+      "year": 1968
+    }
+  ]
+}

--- a/example/big_result-colored.jsdiff
+++ b/example/big_result-colored.jsdiff
@@ -1,0 +1,12 @@
+ {
+   movies: [
+     ... (8 entries)
+     {
+       directors: [
+         "Terry Gilliam"
++        "Terry Jones"
+       ]
+     }
+     ...
+   ]
+ }

--- a/example/big_result.jsdiff
+++ b/example/big_result.jsdiff
@@ -1,0 +1,12 @@
+ {
+   movies: [
+     ... (8 entries)
+     {
+       directors: [
+         "Terry Gilliam"
++        "Terry Jones"
+       ]
+     }
+     ...
+   ]
+ }

--- a/test/colorize_test.coffee
+++ b/test/colorize_test.coffee
@@ -34,6 +34,10 @@ describe 'colorizeToArray', ->
     console.log "output:\n%s", colorizeToArray(input).join("\n")
     assert.deepEqual colorizeToArray(input), expected
 
+  it "should collapse long sequences of identical subobjects into one '...'", ->
+    input = [ [" "], [" "], [" "], [" "], [" "], [" "], [" "], ["~", {"foo__added": 42}], [" "] ]
+    expected = [" [", "   ... (7 entries)", "   {", "+    foo: 42", "   }", "   ...", " ]"]
+    assert.deepEqual colorizeToArray(input), expected
 
 
 describe 'colorize', ->

--- a/test/diff_test.coffee
+++ b/test/diff_test.coffee
@@ -169,12 +169,16 @@ describe 'diffString', ->
   readExampleFile = (file) -> fs.readFileSync(Path.join(__dirname, '../example', file), 'utf8')
   a = JSON.parse(readExampleFile('a.json'))
   b = JSON.parse(readExampleFile('b.json'))
+  big_a = JSON.parse(readExampleFile('big_a.json'))
+  big_b = JSON.parse(readExampleFile('big_b.json'))
 
   it "should produce the expected result for the example JSON files", ->
     assert.equal diffString(a, b, color: no), readExampleFile('result.jsdiff')
+    assert.equal diffString(big_a, big_b, color: no), readExampleFile('big_result.jsdiff')
 
   it "should produce the expected colored result for the example JSON files", ->
     assert.equal diffString(a, b), readExampleFile('result-colored.jsdiff')
+    assert.equal diffString(big_a, big_b, color: no), readExampleFile('big_result-colored.jsdiff')
 
   it "return an empty string when no diff found", ->
     assert.equal diffString(a, a), ''


### PR DESCRIPTION
Collapse five or more `...` lines into one (that looks like `... (12 entries)` or similar.

The added example is illustrative:
```diff
 {
   movies: [
     ... (8 entries)
     {
       directors: [
         "Terry Gilliam"
+        "Terry Jones"
       ]
     }
     ...
   ]
 }
```

This is particularly useful when working with things like API responses, where you might expect arrays of similarly structured objects, with all but a select few being identical. It helps emphasize exactly what the difference between the JSON objects are, which is, after all, what you want to know.