### PR TITLE
Add MIT license to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "description": "JSON diff",
   "version": "0.5.3",
   "homepage": "https://github.com/andreyvit/json-diff",
+  "license": "MIT",
   "repository": {
     "url": "git@github.com:andreyvit/json-diff.git"
   },


### PR DESCRIPTION
The NPM page for this package show it as having no license. From the project it's pretty clear that the license is actually MIT. This will show the right license on the NPM package.

![image](https://user-images.githubusercontent.com/1874242/55107657-40004c80-50a8-11e9-9afb-064c8158e11d.png)
