### PR TITLE
Add support to always output given keys of an object that has diffs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 /lib-cov
 test/*.js
 coverage.html
+.idea

--- a/README.md
+++ b/README.md
@@ -40,13 +40,14 @@ Detailed:
         <second.json>         New file
 
         General options:
-        -v, --verbose         Output progress info
-        -C, --[no-]color      Colored output
-        -j, --raw-json        Display raw JSON encoding of the diff
-        -f, --full            Include the equal sections of the document, not just the deltas
-        -s, --sort            Sort primitive values in arrays before comparing
-        -k, --keys-only       Compare only the keys, ignore the differences in values
-        -h, --help            Display this usage information
+        -v, --verbose           Output progress info
+        -C, --[no-]color        Colored output
+        -j, --raw-json          Display raw JSON encoding of the diff
+        -f, --full              Include the equal sections of the document, not just the deltas
+        -o, --output-keys KEYS  Always print this comma separated keys, with their value, if they are part of an object with any diff.
+        -s, --sort              Sort primitive values in arrays before comparing
+        -k, --keys-only         Compare only the keys, ignore the differences in values
+        -h, --help              Display this usage information
 
 In javascript (ES5):
 
@@ -87,6 +88,7 @@ Features
 * fuzzy matching of modified array elements (when array elements are object hierarchies)
 * "keysOnly" option to compare only the json structure (keys), ignoring the values
 * "full" option to output the entire json tree, not just the deltas
+* "outputKeys" option to always output the given keys for an object that has differences
 * reasonable test coverage (far from 100%, though)
 
 Output Language in Raw-json mode ("full" mode)

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -15,11 +15,14 @@ module.exports = function (argv) {
       '  -C, --[no-]color        Colored output',
       '  -j, --raw-json          Display raw JSON encoding of the diff #var(raw)',
       '  -f, --full              Include the equal sections of the document, not just the deltas #var(full)',
+      '  -o, --output-keys KEYS  Always print this comma separated keys, with their value, if they are part of an object with any diff #var(outputKeys)',
       '  -s, --sort              Sort primitive values in arrays before comparing #var(sort)',
       '  -k, --keys-only         Compare only the keys, ignore the differences in values #var(keysOnly)'
     ],
     argv
   )
+
+  options.outputKeys = options.outputKeys ? options.outputKeys.split(',') : []
 
   if (options.verbose) {
     process.stderr.write(`${JSON.stringify(options, null, 2)}\n`)

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,6 +4,7 @@ const { colorize } = require('./colorize')
 
 class JsonDiff {
   constructor (options) {
+    options.outputKeys = options.outputKeys || [];
     this.options = options
   }
 
@@ -40,7 +41,7 @@ class JsonDiff {
         if (!change.equal) {
           result[key] = change.result
           equal = false
-        } else if (this.options.full || (this.options.outputKeys && this.options.outputKeys.includes(key))) {
+        } else if (this.options.full || this.options.outputKeys.includes(key)) {
           result[key] = value1
         }
         // console.log(`key ${key} change.score=${change.score} ${change.result}`)

--- a/lib/index.js
+++ b/lib/index.js
@@ -40,7 +40,7 @@ class JsonDiff {
         if (!change.equal) {
           result[key] = change.result
           equal = false
-        } else if (this.options.full) {
+        } else if (this.options.full || (this.options.outputKeys && this.options.outputKeys.includes(key))) {
           result[key] = value1
         }
         // console.log(`key ${key} change.score=${change.score} ${change.result}`)

--- a/test/diff_test.coffee
+++ b/test/diff_test.coffee
@@ -199,7 +199,19 @@ describe 'diff({full: true})', ->
                                 { foo: 30, bar: { bbbar: 92, bbboz: 34 } }], {full: true})
       )
 
-   
+describe 'diff({ outputKeys: foo,bar }', ->
+
+  it "should return keys foo and bar although they have no changes", ->
+    assert.deepEqual { foo: 42, bar: 10, bbar__added: 5 }, diff({ foo: 42, bar: 10 }, { foo: 42, bar: 10, bbar: 5 }, {outputKeys: ["foo", "bar"]})
+  it "should return keys foo (with addition) and bar (with no changes) ", ->
+    assert.deepEqual { foo__added: 42, bar: 10, bbar__added: 5 }, diff({ bar: 10 }, { foo: 42, bar: 10, bbar: 5 }, {outputKeys: ["foo", "bar"]})
+  it "should return keys foo and bar (with addition) ", ->
+    assert.deepEqual { foo__added: 42, bar__added: 10 }, diff({ bbar: 5 }, { foo: 42, bar: 10, bbar: 5 }, {outputKeys: ["foo", "bar"]})
+  it "should return nothing as the entire object is equal, no matter that show keys has some of them", ->
+    assert.deepEqual undefined, diff({ foo: 42, bar: 10, bbar: 5 }, { foo: 42, bar: 10, bbar: 5 }, {outputKeys: ["foo", "bar"]})
+  it "should return the keys of an entire object although it has no changes ", ->
+    assert.deepEqual { foo: { a: 1, b: 2, c: [1, 2] }, bbar__added: 5 }, diff({ foo: { a: 1, b: 2, c: [1, 2] } }, { foo: { a: 1, b: 2, c: [1, 2] }, bbar: 5 }, {outputKeys: ["foo", "bar"]})
+
 describe 'diff({keysOnly: true})', ->
 
   describe 'with simple scalar values', ->


### PR DESCRIPTION
This adds a new functionality to always show the given object keys (with their value) if the object has any diff.

For example, having the following json:

a.json
```json
{
  "foo": 10,
  "bar": 15
}
```

b.json
```json
{
  "foo": 10,
  "bar": 49
}
```

If you run `json-diff.js --show-keys foo a.json b.json`, you get:
```
 {
   foo: 10
-  bar: 15
+  bar: 49
 }
```

If you run it without show-keys, like: `json-diff.js a.json b.json`, you get:

```
 {
-  bar: 15
+  bar: 49
 }
```