### PR TITLE
Explicitly track original index position in scalarize/findMatchingObject

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -113,6 +113,7 @@ class JsonDiff {
     for (let index = 0; index < array.length; index++) {
       const item = array[index]
       if (this.isScalar(item)) {
+        originals[key] = item
         result.push(item)
       } else {
         const key = fuzzyMatches[index] || '__$!SCALAR' + originals.__next++

--- a/lib/index.js
+++ b/lib/index.js
@@ -66,8 +66,7 @@ class JsonDiff {
     // console.log("findMatchingObject: " + JSON.stringify({item, fuzzyOriginals}, null, 2))
     let bestMatch = null
 
-    let matchIndex = 0
-    for (const [key, candidate] of Object.entries(fuzzyOriginals)) {
+    for (const [key, { item: candidate, index: matchIndex }] of Object.entries(fuzzyOriginals)) {
       if (key !== '__next') {
         const indexDistance = Math.abs(matchIndex - index)
         if (extendedTypeOf(item) === extendedTypeOf(candidate)) {
@@ -81,7 +80,6 @@ class JsonDiff {
             bestMatch = { score, key, indexDistance }
           }
         }
-        matchIndex++
       }
     }
 
@@ -113,11 +111,10 @@ class JsonDiff {
     for (let index = 0; index < array.length; index++) {
       const item = array[index]
       if (this.isScalar(item)) {
-        originals[key] = item
         result.push(item)
       } else {
         const key = fuzzyMatches[index] || '__$!SCALAR' + originals.__next++
-        originals[key] = item
+        originals[key] = { item, index };
         result.push(key)
       }
     }
@@ -130,7 +127,7 @@ class JsonDiff {
 
   descalarize (item, originals) {
     if (this.isScalarized(item, originals)) {
-      return originals[item]
+      return originals[item].item
     } else {
       return item
     }

--- a/test/diff_test.coffee
+++ b/test/diff_test.coffee
@@ -101,7 +101,7 @@ describe 'diff', ->
       assert.deepEqual( { "s": [ [ "~", [ [ "~", { "b": { "__old": "123", "__new": "abc" } } ] ] ], [ "+", [] ] ] },  
                         diff({"s": [[{ "b": "123" }]]}, {"s": [[{ "b": "abc" }], []]} ) )
       
-    it "bug 76", ->
+    it "should handle mixed scalars and non-scalars in scalarize", ->
       assert.deepEqual( undefined,  
                         diff(["a", {"foo": "bar"}, {"foo": "bar"}], ["a", {"foo": "bar"}, {"foo": "bar"}] ) )
 

--- a/test/diff_test.coffee
+++ b/test/diff_test.coffee
@@ -100,7 +100,10 @@ describe 'diff', ->
     it "should handle type mismatch during scalarize", ->
       assert.deepEqual( { "s": [ [ "~", [ [ "~", { "b": { "__old": "123", "__new": "abc" } } ] ] ], [ "+", [] ] ] },  
                         diff({"s": [[{ "b": "123" }]]}, {"s": [[{ "b": "abc" }], []]} ) )
-
+      
+    it "bug 76", ->
+      assert.deepEqual( undefined,  
+                        diff(["a", {"foo": "bar"}, {"foo": "bar"}], ["a", {"foo": "bar"}, {"foo": "bar"}] ) )
 
 describe 'diff({sort: true})', ->
   describe 'with arrays', ->


### PR DESCRIPTION
Fixes https://github.com/andreyvit/json-diff/issues/76

Currently `findMatchingObject` determines the candidate's original index position via its position in the entries of `fuzzyOriginals`, but this index position can be off from the actual index position if the array that was scalarized contained scalar values mixed in with the non-scalar ones.

This change tracks the original index position explicitly instead.

An alternative might be adding a placeholder value (say, `originals[item] = [item];`) for already-scalar values but this seems less logical.