### PR TITLE
Feature/output new only option

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ Detailed:
         -f, --full              Include the equal sections of the document, not just the deltas
               --max-elisions COUNT  Max number of ...'s to show in a row in "deltas" mode (before collapsing them)
         -o, --output-keys KEYS  Always print these [comma separated] keys, with their values, if they are in an object with a diff
+        -n, --output-new-only   Output only the added and new diffs (without marking them as such). If
+                                you need only the diffs from the old file, just exchange the first and second json.
         -s, --sort              Sort primitive values in arrays before comparing
         -k, --keys-only         Compare only the keys, ignore the differences in values
         -h, --help              Display this usage information

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Detailed:
         -f, --full              Include the equal sections of the document, not just the deltas
               --max-elisions COUNT  Max number of ...'s to show in a row in "deltas" mode (before collapsing them)
         -o, --output-keys KEYS  Always print these [comma separated] keys, with their values, if they are in an object with a diff
-        -n, --output-new-only   Output only the added and new diffs (without marking them as such). If
+        -n, --output-new-only   Output only the updated and new key/value pairs (without marking them as such). If
                                 you need only the diffs from the old file, just exchange the first and second json.
         -s, --sort              Sort primitive values in arrays before comparing
         -k, --keys-only         Compare only the keys, ignore the differences in values

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -17,7 +17,7 @@ module.exports = function (argv) {
       '  -f, --full              Include the equal sections of the document, not just the deltas #var(full)',
       '  --max-elisions COUNT    Max number of ...\'s to show in a row in "deltas" mode (before collapsing them) #var(maxElisions)',
       '  -o, --output-keys KEYS  Always print this comma separated keys, with their value, if they are part of an object with any diff #var(outputKeys)',
-      '  -n, --output-new-only   Output only the added and new diffs (without marking them as such). If you need only the diffs from the old file, just exchange the first and second json. #var(outputNewOnly)',
+      '  -n, --output-new-only   Output only the updated and new key/value pairs (without marking them as such). If you need only the diffs from the old file, just exchange the first and second json. #var(outputNewOnly)',
       '  -s, --sort              Sort primitive values in arrays before comparing #var(sort)',
       '  -k, --keys-only         Compare only the keys, ignore the differences in values #var(keysOnly)',
       '  -p, --precision DECIMALS  Round all floating point numbers to this number of decimal places prior to comparison'

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -7,7 +7,7 @@ const { colorize } = require('./colorize')
 module.exports = function (argv) {
   const options = require('dreamopt')(
     [
-      'Usage: json-diff [-vCjfskp] first.json second.json',
+      'Usage: json-diff [-vCjfonskp] first.json second.json',
       '  <first.json>              Old file #var(file1) #required',
       '  <second.json>             New file #var(file2) #required',
       'General options:',
@@ -17,6 +17,7 @@ module.exports = function (argv) {
       '  -f, --full              Include the equal sections of the document, not just the deltas #var(full)',
       '  --max-elisions COUNT    Max number of ...\'s to show in a row in "deltas" mode (before collapsing them) #var(maxElisions)',
       '  -o, --output-keys KEYS  Always print this comma separated keys, with their value, if they are part of an object with any diff #var(outputKeys)',
+      '  -n, --output-new-only   Output only the added and new diffs (without marking them as such). If you need only the diffs from the old file, just exchange the first and second json. #var(outputNewOnly)',
       '  -s, --sort              Sort primitive values in arrays before comparing #var(sort)',
       '  -k, --keys-only         Compare only the keys, ignore the differences in values #var(keysOnly)',
       '  -p, --precision DECIMALS  Round all floating point numbers to this number of decimal places prior to comparison'

--- a/lib/index.js
+++ b/lib/index.js
@@ -18,16 +18,22 @@ class JsonDiff {
     let equal = true
 
     for (const [key, value] of Object.entries(obj1)) {
-      if (!(key in obj2)) {
-        result[`${key}__deleted`] = value
-        score -= 30
-        equal = false
+      if (! this.options.outputNewOnly) {
+        let postfix = "__deleted"
+
+        if (!(key in obj2)) {
+          result[`${key}${postfix}`] = value
+          score -= 30
+          equal = false
+        }
       }
     }
 
     for (const [key, value] of Object.entries(obj2)) {
+      let postfix = ! this.options.outputNewOnly ? "__added" : ""
+
       if (!(key in obj1)) {
-        result[`${key}__added`] = value
+        result[`${key}${postfix}`] = value
         score -= 30
         equal = false
       }
@@ -298,7 +304,12 @@ class JsonDiff {
       equal = obj1 === obj2
       if (!equal) {
         score = 0
-        result = { __old: obj1, __new: obj2 }
+
+        if (this.options.outputNewOnly) {
+          result = obj2
+        } else {
+          result = { __old: obj1, __new: obj2 }
+        }
       } else if (!this.options.full) {
         result = undefined
       }

--- a/test/diff_test.coffee
+++ b/test/diff_test.coffee
@@ -317,3 +317,18 @@ describe 'diffString', ->
 
   it "return an empty string when no diff found", ->
     assert.equal diffString(a, a), ''
+
+describe 'diff({ outputNewOnly: true }', ->
+
+  it "should return only new diffs (added)", ->
+    assert.deepEqual { bbar: 5 }, diff({ foo: 42, bar: 10 }, { foo: 42, bar: 10, bbar: 5 }, {outputNewOnly: true})
+  it "should return only new diffs (changed)", ->
+      assert.deepEqual { foo: 13, bbar: 5 }, diff({ foo: 42, bar: 10 }, { foo: 13, bar: 10, bbar: 5 }, {outputNewOnly: true})
+  it "should return only new diffs (deleted)", ->
+      assert.deepEqual { bbar: 5 }, diff({ foo: 42, bar: 10 }, { bar: 10, bbar: 5 }, {outputNewOnly: true})
+  it "should return only old diffs - exchanged first and second json (added)", ->
+    assert.deepEqual undefined, diff({ foo: 42, bar: 10, bbar: 5 }, { foo: 42, bar: 10 }, {outputNewOnly: true})
+  it "should return only old diffs - exchanged first and second json (changed)", ->
+      assert.deepEqual { foo: 42 }, diff({ foo: 13, bar: 10, bbar: 5 }, { foo: 42, bar: 10 }, {outputNewOnly: true})
+  it "should return only old diffs - exchanged first and second json (deleted)", ->
+      assert.deepEqual { foo: 42 }, diff({ bar: 10, bbar: 5 }, { foo: 42, bar: 10 }, {outputNewOnly: true})


### PR DESCRIPTION
Output only the updated and new key/value pairs (without marking them as such). If you need only the diffs from the old file, just exchange the first and second json.

This is useful when e.g. comparing the updated and new keys for updating translation locales in your application.