### PR TITLE
json-diff cli return exit code 1 in shell when there is a diff

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -74,10 +74,12 @@ module.exports = function (argv) {
       }
       process.stdout.write(colorize(result, colorizeOptions))
     }
+    process.exit(1)
   } else {
     if (options.verbose) {
       process.stderr.write('No diff')
     }
+    process.exit(0)
   }
-  process.exit(0)
+
 }


### PR DESCRIPTION
Return exit code 1 when running the cli and diff was found 

Related [issue](https://github.com/andreyvit/json-diff/issues/88)