### PR TITLE
fix(docs): make readme more readable

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ Does exactly what you think it does:
 Installation
 ------------
 
+```sh
     npm install -g json-diff
+```
 
 
 Contribution policy
@@ -25,12 +27,15 @@ Contribution policy
 Usage
 -----
 
-Simple:
+Simple:  
 
+```sh
     json-diff a.json b.json
+```
 
-Detailed:
+Detailed:  
 
+```sh
     % json-diff --help
 
     Usage: json-diff [-vCjfonskKp] first.json second.json
@@ -44,7 +49,7 @@ Detailed:
     -C, --[no-]color      Colored output
     -j, --raw-json        Display raw JSON encoding of the diff
     -f, --full            Include the equal sections of the document, not just the deltas
-        --max-elisions COUNT  Max number of ...'s to show in a row in "deltas" mode (before
+        --max-elisions COUNT  Max number of ...s to show in a row in "deltas" mode (before
                                 collapsing them)
 
     -o, --output-keys KEYS  Always print this comma separated keys, with their value, if they are
@@ -63,9 +68,11 @@ Detailed:
                                 to comparison
 
     -h, --help            Display this usage information
+```
 
-In javascript (ES5):
+In javascript (ES5):  
 
+```js
     var jsonDiff = require('json-diff')
     
     console.log(jsonDiff.diffString({ foo: 'bar' }, { foo: 'baz' }));
@@ -87,14 +94,16 @@ In javascript (ES5):
     console.log(jsonDiff.diff({ foo: 'bar', b:3}, { foo: 'baz', b:3}, {full:true}));
     // Output:
     // { foo: { __old: 'bar', __new: 'baz' }, b: 3 }
-    
+```
 
-In javascript (ES6+):
+In javascript (ES6+):  
 
+```js
     import { diffString, diff } from 'json-diff';
     
     console.log(diffString({ foo: 'bar' }, { foo: 'baz' }));
     console.log(diff({ foo: 'bar' }, { foo: 'baz' }));
+```
 
 Features
 --------
@@ -113,47 +122,60 @@ Output Language in Raw-json mode ("full" mode)
 
 Unless two arrays are equal, all array elements are transformed into 2-tuple arrays:
 * The first element is a one character string denoting the equality ('+', '-', '~', ' ')
-* The second element is the old (-), new (+), altered sub-object (~), or unchanged (' ') value
->
+* The second element is the old (-), new (+), altered sub-object (~), or unchanged (' ') value  
+
+```sh
     json-diff.js --full --raw-json <(echo '[1,7,3]') <(echo '[1,2,3]')
          [ [ " ", 1 ], [ "-", 7 ], [ "+", 2 ], [ " ", 3 ] ]
+```
 
+```sh
     json-diff.js --full --raw-json <(echo '[1,["a","b"],4]') <(echo '[1,["a","c"],4]')
          [ [ " ", 1 ], [ "~", [ [ " ", "a" ], [ "-", "b" ], [ "+", "c" ] ] ], [ " ", 4 ] ]
+```
 * If two arrays are equal, they are left as is.
 
 ### OBJECTS
 
-Object property values:
+**Object property values:**  
 * If equal, they are left as is
-* Unequal scalar values are replaced by an object containing the old and new value:
->
+* Unequal scalar values are replaced by an object containing the old and new value:  
+
+```sh
     json-diff.js --full  --raw-json <(echo '{"a":4}') <(echo '{"a":5}')
         { "a": { "__old": 4, "__new": 5 } }
-    
+``` 
 * Unequal arrays and objects are replaced by their diff:
->
+```sh
     json-diff.js --full  --raw-json <(echo '{"a":[4,5]}') <(echo '{"a":[4,6]}')
         { "a": [ [ " ", 4 ], [ "-", 5 ], [ "+", 6 ] ] }
+```
 
-Object property keys:
+**Object property keys:**  
+
 * Object keys that are deleted or added between two objects are marked as such:
->
+```sh
     json-diff.js --full  --raw-json <(echo '{"a":[4,5]}') <(echo '{"b":[4,5]}')
         { "a__deleted": [ 4, 5 ], "b__added": [ 4, 5 ] }
     json-diff.js --full  --raw-json <(echo '{"a":[4,5]}') <(echo '{"b":[4,6]}')
         { "a__deleted": [ 4, 5 ], "b__added": [ 4, 6 ] }
+```
 
-### Non-full mode
+## Non-full mode
+
 * In regular, delta-only (non-"full") mode, equal properties and values are omitted:
->
+
+```sh
     json-diff.js --raw-json <(echo '{"a":4, "b":6}') <(echo '{"a":5,"b":6}')
         { "a": { "__old": 4, "__new": 5 } }
+```
 
 * Equal array elements are represented by a one-tuple containing only a space " ":
->
+
+```sh
     json-diff.js --raw-json <(echo '[1,7,3]') <(echo '[1,2,3]')
         [ [ " " ], [ "-", 7 ], [ "+", 2 ], [ " " ] ]
+```
 
 
 Tests
@@ -161,9 +183,13 @@ Tests
 
 Run:
 
+```sh
     npm test
+```
 
 Output:
+<details>
+  <summary><b> Open to View Test Output 🔽 </b></summary>
 
     json-diff@0.5.3 test
     coffee -c test; mocha test/*.js
@@ -312,25 +338,27 @@ Output:
 
 
   107 passing (74ms)
+</details>
 
 Change Log
 ----------
- * 1.0.0 Properly distinguish list elements with identical strings of different types e.g. ["true"] vs [true], ["0"] vs [0] (enabled by switching to a new difflib)
- * 0.10.0 Add --exclude-keys
- * 0.9.1 Fix bug #88
- * 0.9.0 Add --output-new-only option
- * 0.8.0 Add --keep-unchanged-values option
- * 0.7.4 Fix bug #76
- * 0.7.3 Revert use of ?? operator in 0.7.2 (which caused a breaking change)
- * 0.7.2 Add --maxElisions and --precision options.
- * 0.7.1 Add --output-keys option.
- * 0.7.0 Add --sort option.
- * 0.6.3 Fix ticket #68.
- * 0.6.2 Provide examples of setting mode from code.
- * 0.6.1 Return exit code 0. Update cli-color to the latest version.
- * 0.6.0 Convert project code to ES6.
- * 0.5.5 Fix bug in scalarize fuzzy compare logic.
- * 0.4.0 Add --keys-only feature.
+
+* 1.0.0 Properly distinguish list elements with identical strings of different types e.g. `["true"]` vs `[true]`, `["0"]` vs `[0]` (enabled by switching to a new difflib)
+* 0.10.0 Add --exclude-keys
+* 0.9.1 Fix bug #88
+* 0.9.0 Add --output-new-only option
+* 0.8.0 Add --keep-unchanged-values option
+* 0.7.4 Fix bug #76
+* 0.7.3 Revert use of ?? operator in 0.7.2 (which caused a breaking change)
+* 0.7.2 Add --maxElisions and --precision options.
+* 0.7.1 Add --output-keys option.
+* 0.7.0 Add --sort option.
+* 0.6.3 Fix ticket #68.
+* 0.6.2 Provide examples of setting mode from code.
+* 0.6.1 Return exit code 0. Update cli-color to the latest version.
+* 0.6.0 Convert project code to ES6.
+* 0.5.5 Fix bug in scalarize fuzzy compare logic.
+* 0.4.0 Add --keys-only feature.
 
 License
 -------

--- a/README.md
+++ b/README.md
@@ -1,21 +1,16 @@
-JSON structural diff
-====================
+# JSON structural diff
 
 Does exactly what you think it does:
 
 ![Screenshot](https://github.com/andreyvit/json-diff/raw/master/doc/screenshot.png)
 
-
-Installation
-------------
+## Installation
 
 ```sh
     npm install -g json-diff
 ```
 
-
-Contribution policy
--------------------
+## Contribution policy
 
 1. This project is maintained thanks to your contributions! Please send pull requests.
 
@@ -23,17 +18,15 @@ Contribution policy
 
 3. Anyone who gets a significant pull request merged gets commit access to the repository.
 
+## Usage
 
-Usage
------
-
-Simple:  
+Simple:
 
 ```sh
     json-diff a.json b.json
 ```
 
-Detailed:  
+Detailed:
 
 ```sh
     % json-diff --help
@@ -70,59 +63,58 @@ Detailed:
     -h, --help            Display this usage information
 ```
 
-In javascript (ES5):  
+In javascript (ES5):
 
 ```js
-    var jsonDiff = require('json-diff')
-    
-    console.log(jsonDiff.diffString({ foo: 'bar' }, { foo: 'baz' }));
-    // Output:
-    //  {
-    // -  foo: "bar"
-    // +  foo: "baz"
-    //  }
-    
-    // As above, but without console colors
-    console.log(jsonDiff.diffString({ foo: 'bar' }, { foo: 'baz' }, {color:false}));
-    
-    // Raw output:
-    console.log(jsonDiff.diff({ foo: 'bar', b:3}, { foo: 'baz', b:3}));
-    // Output:
-    // { foo: { __old: 'bar', __new: 'baz' } }
+var jsonDiff = require('json-diff');
 
-    // Passing in the "full" option:
-    console.log(jsonDiff.diff({ foo: 'bar', b:3}, { foo: 'baz', b:3}, {full:true}));
-    // Output:
-    // { foo: { __old: 'bar', __new: 'baz' }, b: 3 }
+console.log(jsonDiff.diffString({ foo: 'bar' }, { foo: 'baz' }));
+// Output:
+//  {
+// -  foo: "bar"
+// +  foo: "baz"
+//  }
+
+// As above, but without console colors
+console.log(jsonDiff.diffString({ foo: 'bar' }, { foo: 'baz' }, { color: false }));
+
+// Raw output:
+console.log(jsonDiff.diff({ foo: 'bar', b: 3 }, { foo: 'baz', b: 3 }));
+// Output:
+// { foo: { __old: 'bar', __new: 'baz' } }
+
+// Passing in the "full" option:
+console.log(jsonDiff.diff({ foo: 'bar', b: 3 }, { foo: 'baz', b: 3 }, { full: true }));
+// Output:
+// { foo: { __old: 'bar', __new: 'baz' }, b: 3 }
 ```
 
-In javascript (ES6+):  
+In javascript (ES6+):
 
 ```js
-    import { diffString, diff } from 'json-diff';
-    
-    console.log(diffString({ foo: 'bar' }, { foo: 'baz' }));
-    console.log(diff({ foo: 'bar' }, { foo: 'baz' }));
+import { diffString, diff } from 'json-diff';
+
+console.log(diffString({ foo: 'bar' }, { foo: 'baz' }));
+console.log(diff({ foo: 'bar' }, { foo: 'baz' }));
 ```
 
-Features
---------
+## Features
 
-* colorized, diff-like output
-* fuzzy matching of modified array elements (when array elements are object hierarchies)
-* "keysOnly" option to compare only the json structure (keys), ignoring the values
-* "full" option to output the entire json tree, not just the deltas
-* "outputKeys" option to always output the given keys for an object that has differences
-* reasonable test coverage (far from 100%, though)
+- colorized, diff-like output
+- fuzzy matching of modified array elements (when array elements are object hierarchies)
+- "keysOnly" option to compare only the json structure (keys), ignoring the values
+- "full" option to output the entire json tree, not just the deltas
+- "outputKeys" option to always output the given keys for an object that has differences
+- reasonable test coverage (far from 100%, though)
 
-Output Language in Raw-json mode ("full" mode)
---------
+## Output Language in Raw-json mode ("full" mode)
 
 ### ARRAYS
 
 Unless two arrays are equal, all array elements are transformed into 2-tuple arrays:
-* The first element is a one character string denoting the equality ('+', '-', '~', ' ')
-* The second element is the old (-), new (+), altered sub-object (~), or unchanged (' ') value  
+
+- The first element is a one character string denoting the equality ('+', '-', '~', ' ')
+- The second element is the old (-), new (+), altered sub-object (~), or unchanged (' ') value
 
 ```sh
     json-diff.js --full --raw-json <(echo '[1,7,3]') <(echo '[1,2,3]')
@@ -133,27 +125,32 @@ Unless two arrays are equal, all array elements are transformed into 2-tuple arr
     json-diff.js --full --raw-json <(echo '[1,["a","b"],4]') <(echo '[1,["a","c"],4]')
          [ [ " ", 1 ], [ "~", [ [ " ", "a" ], [ "-", "b" ], [ "+", "c" ] ] ], [ " ", 4 ] ]
 ```
-* If two arrays are equal, they are left as is.
+
+- If two arrays are equal, they are left as is.
 
 ### OBJECTS
 
-**Object property values:**  
-* If equal, they are left as is
-* Unequal scalar values are replaced by an object containing the old and new value:  
+**Object property values:**
+
+- If equal, they are left as is
+- Unequal scalar values are replaced by an object containing the old and new value:
 
 ```sh
     json-diff.js --full  --raw-json <(echo '{"a":4}') <(echo '{"a":5}')
         { "a": { "__old": 4, "__new": 5 } }
-``` 
-* Unequal arrays and objects are replaced by their diff:
+```
+
+- Unequal arrays and objects are replaced by their diff:
+
 ```sh
     json-diff.js --full  --raw-json <(echo '{"a":[4,5]}') <(echo '{"a":[4,6]}')
         { "a": [ [ " ", 4 ], [ "-", 5 ], [ "+", 6 ] ] }
 ```
 
-**Object property keys:**  
+**Object property keys:**
 
-* Object keys that are deleted or added between two objects are marked as such:
+- Object keys that are deleted or added between two objects are marked as such:
+
 ```sh
     json-diff.js --full  --raw-json <(echo '{"a":[4,5]}') <(echo '{"b":[4,5]}')
         { "a__deleted": [ 4, 5 ], "b__added": [ 4, 5 ] }
@@ -163,23 +160,21 @@ Unless two arrays are equal, all array elements are transformed into 2-tuple arr
 
 ## Non-full mode
 
-* In regular, delta-only (non-"full") mode, equal properties and values are omitted:
+- In regular, delta-only (non-"full") mode, equal properties and values are omitted:
 
 ```sh
     json-diff.js --raw-json <(echo '{"a":4, "b":6}') <(echo '{"a":5,"b":6}')
         { "a": { "__old": 4, "__new": 5 } }
 ```
 
-* Equal array elements are represented by a one-tuple containing only a space " ":
+- Equal array elements are represented by a one-tuple containing only a space " ":
 
 ```sh
     json-diff.js --raw-json <(echo '[1,7,3]') <(echo '[1,2,3]')
         [ [ " " ], [ "-", 7 ], [ "+", 2 ], [ " " ] ]
 ```
 
-
-Tests
------
+## Tests
 
 Run:
 
@@ -340,27 +335,25 @@ Output:
   107 passing (74ms)
 </details>
 
-Change Log
-----------
+## Change Log
 
-* 1.0.0 Properly distinguish list elements with identical strings of different types e.g. `["true"]` vs `[true]`, `["0"]` vs `[0]` (enabled by switching to a new difflib)
-* 0.10.0 Add --exclude-keys
-* 0.9.1 Fix bug #88
-* 0.9.0 Add --output-new-only option
-* 0.8.0 Add --keep-unchanged-values option
-* 0.7.4 Fix bug #76
-* 0.7.3 Revert use of ?? operator in 0.7.2 (which caused a breaking change)
-* 0.7.2 Add --maxElisions and --precision options.
-* 0.7.1 Add --output-keys option.
-* 0.7.0 Add --sort option.
-* 0.6.3 Fix ticket #68.
-* 0.6.2 Provide examples of setting mode from code.
-* 0.6.1 Return exit code 0. Update cli-color to the latest version.
-* 0.6.0 Convert project code to ES6.
-* 0.5.5 Fix bug in scalarize fuzzy compare logic.
-* 0.4.0 Add --keys-only feature.
+- 1.0.0 Properly distinguish list elements with identical strings of different types e.g. `["true"]` vs `[true]`, `["0"]` vs `[0]` (enabled by switching to a new difflib)
+- 0.10.0 Add --exclude-keys
+- 0.9.1 Fix bug #88
+- 0.9.0 Add --output-new-only option
+- 0.8.0 Add --keep-unchanged-values option
+- 0.7.4 Fix bug #76
+- 0.7.3 Revert use of ?? operator in 0.7.2 (which caused a breaking change)
+- 0.7.2 Add --maxElisions and --precision options.
+- 0.7.1 Add --output-keys option.
+- 0.7.0 Add --sort option.
+- 0.6.3 Fix ticket #68.
+- 0.6.2 Provide examples of setting mode from code.
+- 0.6.1 Return exit code 0. Update cli-color to the latest version.
+- 0.6.0 Convert project code to ES6.
+- 0.5.5 Fix bug in scalarize fuzzy compare logic.
+- 0.4.0 Add --keys-only feature.
 
-License
--------
+## License
 
 © Andrey Tarantsov. Distributed under the MIT license.


### PR DESCRIPTION
- Use `sh` code blocks instead of quote style for proper syntax highlighting
- Use "`" for inline code 
- Use `js` for javascript codeblocks for proper syntax highlighting
- Keep the test output inside toggle list
- Add "  " for line break