### PR TITLE
Fix output-keys var typo

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -16,7 +16,7 @@ module.exports = function (argv) {
       '  -j, --raw-json          Display raw JSON encoding of the diff #var(raw)',
       '  -f, --full              Include the equal sections of the document, not just the deltas #var(full)',
       '  --max-elisions COUNT    Max number of ...\'s to show in a row in "deltas" mode (before collapsing them) #var(maxElisions)',
-      '  -o, --output-keys KEYS  Always print this comma separated keys, with their value, if they are part of an object with any diff #var(excludeKeys)',
+      '  -o, --output-keys KEYS  Always print this comma separated keys, with their value, if they are part of an object with any diff #var(outputKeys)',
       '  -x, --exclude-keys KEYS  Exclude these comma separated keys from comparison on both files #var(excludeKeys)',
       '  -n, --output-new-only   Output only the updated and new key/value pairs (without marking them as such). If you need only the diffs from the old file, just exchange the first and second json. #var(outputNewOnly)',
       '  -s, --sort              Sort primitive values in arrays before comparing #var(sort)',


### PR DESCRIPTION
Fixed the output-keys var typo mentioned here: https://github.com/andreyvit/json-diff/issues/115